### PR TITLE
Add Multi-Threading Processing on Links

### DIFF
--- a/src/main/java/Application.java
+++ b/src/main/java/Application.java
@@ -4,13 +4,17 @@ import java.time.Instant;
 public class Application {
 
     public static void main(String[] args) throws Exception {
-        if (args == null || args.length != 1) {
+        if (args == null || args.length < 2) {
             System.out.println("Please provide site to crawl");
             System.exit(1);
         }
 
         String site = args[0];
-        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler(site);
+        String externalLinkFilter = null;
+        if (args.length == 2) {
+            externalLinkFilter = args[1];
+        }
+        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler(site, externalLinkFilter);
         Instant start = Instant.now();
         simpleWebCrawler.crawlSite();
         long timeElapsedInMillis = Duration.between(start, Instant.now()).toMillis();

--- a/src/main/java/Application.java
+++ b/src/main/java/Application.java
@@ -10,11 +10,11 @@ public class Application {
         }
 
         String site = args[0];
-        String externalLinkFilter = null;
+        String linkFilter = null;
         if (args.length == 2) {
-            externalLinkFilter = args[1];
+            linkFilter = args[1];
         }
-        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler(site, externalLinkFilter);
+        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler(site, linkFilter);
         Instant start = Instant.now();
         simpleWebCrawler.crawlSite();
         long timeElapsedInMillis = Duration.between(start, Instant.now()).toMillis();

--- a/src/main/java/Application.java
+++ b/src/main/java/Application.java
@@ -1,3 +1,6 @@
+import java.time.Duration;
+import java.time.Instant;
+
 public class Application {
 
     public static void main(String[] args) throws Exception {
@@ -8,8 +11,21 @@ public class Application {
 
         String site = args[0];
         SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler(site);
+        Instant start = Instant.now();
         simpleWebCrawler.crawlSite();
+        long timeElapsedInMillis = Duration.between(start, Instant.now()).toMillis();
         simpleWebCrawler.printSummary();
         simpleWebCrawler.exportResultsToFile();
+        System.out.println("Time to Crawl: " + formatElapsedTime(timeElapsedInMillis));
+    }
+
+    public static String formatElapsedTime(long milliseconds) {
+        String format = String.format("%%0%dd", 2);
+        long elapsedTime = milliseconds / 1000;
+        String seconds = String.format(format, elapsedTime % 60);
+        String minutes = String.format(format, (elapsedTime % 3600) / 60);
+        String hours = String.format(format, elapsedTime / 3600);
+        String time = hours + ":" + minutes + ":" + seconds;
+        return time;
     }
 }

--- a/src/main/java/SimpleWebCrawler.java
+++ b/src/main/java/SimpleWebCrawler.java
@@ -11,20 +11,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SimpleWebCrawler {
 
     private URL site;
+    private String externalLinkFilter;
     private Set<String> visitedLinks = Collections.newSetFromMap(new ConcurrentHashMap<>()); //new HashSet<>();
     private Set<String> externalLinks = Collections.newSetFromMap(new ConcurrentHashMap<>()); //new HashSet<>();
     private Set<String> staticContentLinks = Collections.newSetFromMap(new ConcurrentHashMap<>()); //new HashSet<>();
     private Set<String> unprocessedLinks = Collections.newSetFromMap(new ConcurrentHashMap<>()); //new HashSet<>();
 
-    public SimpleWebCrawler(String site) throws MalformedURLException {
+    public SimpleWebCrawler(String site, String externalLinkFilter) throws MalformedURLException {
         this.site = new URL(site);
+        this.externalLinkFilter = externalLinkFilter;
     }
 
     public void crawlSite() {
@@ -91,7 +92,10 @@ public class SimpleWebCrawler {
                 return;
             }
             if (isExternalLink(elementLink)) {
-                externalLinks.add(elementLink.toExternalForm());
+                String linkExternalForm = elementLink.toExternalForm();
+                if (externalLinkFilter != null && linkExternalForm.toLowerCase().contains(externalLinkFilter.toLowerCase())) {
+                    externalLinks.add(linkExternalForm);
+                }
                 return;
             }
             if (!isHTMLContent(elementLink)) {

--- a/src/test/java/SimpleWebCrawlerTest.java
+++ b/src/test/java/SimpleWebCrawlerTest.java
@@ -12,12 +12,12 @@ public class SimpleWebCrawlerTest {
 
     @Test(expected = MalformedURLException.class)
     public void invalidSite() throws Exception {
-        new SimpleWebCrawler("invalid-url");
+        new SimpleWebCrawler("invalid-url", null);
     }
 
     @Test
     public void isExternalLink() throws MalformedURLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com");
+        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com", null);
         Method method = SimpleWebCrawler.class.getDeclaredMethod("isExternalLink", URL.class);
         method.setAccessible(true);
         boolean isExternal = (boolean) method.invoke(simpleWebCrawler, new URL("https://some.other.site.com"));
@@ -26,7 +26,7 @@ public class SimpleWebCrawlerTest {
 
     @Test
     public void isNotExternalLink() throws MalformedURLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com");
+        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com", null);
         Method method = SimpleWebCrawler.class.getDeclaredMethod("isExternalLink", URL.class);
         method.setAccessible(true);
         boolean isExternal = (boolean) method.invoke(simpleWebCrawler, new URL("https://google.com"));
@@ -35,7 +35,7 @@ public class SimpleWebCrawlerTest {
 
     @Test
     public void isValidLink() throws MalformedURLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com");
+        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com", null);
         Method method = SimpleWebCrawler.class.getDeclaredMethod("isValidLink", String.class);
         method.setAccessible(true);
         boolean isValid = (boolean) method.invoke(simpleWebCrawler, "https://some.other.site.com");
@@ -44,7 +44,7 @@ public class SimpleWebCrawlerTest {
 
     @Test
     public void isNotValidLink() throws MalformedURLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com");
+        SimpleWebCrawler simpleWebCrawler = new SimpleWebCrawler("https://google.com", null);
         Method method = SimpleWebCrawler.class.getDeclaredMethod("isValidLink", String.class);
         method.setAccessible(true);
         boolean isValid = (boolean) method.invoke(simpleWebCrawler, "invalid-site");


### PR DESCRIPTION
Updates to add multi-threaded processing on Links. See outputs below for crawler run time.

**Single-Threaded:**
Links Visited Total: 227
External Links Total: 370
Static Content Links Total: 312
Unprocessed Links Total: 0
Time to Crawl: 00:04:21

**Mutli-Threaded:**
Links Visited Total: 227
External Links Total: 370
Static Content Links Total: 312
Unprocessed Links Total: 0
Time to Crawl: 00:00:42